### PR TITLE
fix(test): 修正 CN 区域的起始年份断言错误

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -120,7 +120,7 @@ async function runTests(options = {}) {
     // Test CN region info
     const cnRegion = index.regions.find(r => r.name === 'CN');
     assert(cnRegion, 'Index should contain CN region');
-    assert(cnRegion.startYear === 2000, 'CN should start from 2002');
+    assert(cnRegion.startYear === 2000, 'CN should start from 2000');
     assert(cnRegion.endYear === 2025, 'CN should end at 2025');
 
     // Test JP region info


### PR DESCRIPTION
- 将 CN 区域的起始年份断言从 2002 修改为 2000 -保持其他断言逻辑不变